### PR TITLE
mgc, projectomes wording, title changes

### DIFF
--- a/content/projects/projectomes.html
+++ b/content/projects/projectomes.html
@@ -65,7 +65,7 @@ related_papers:
 <div class="detail-wrap">
     <div class="intro clearfix" id="about">
         <h3>About</h3>
-        <p>This page hosts projectomes produced with <a href="https://github.com/neurodata/ndmg" target="_blank">NeuroData's MRI Graphs pipeline (ndmg)</a>. A 'projectome' is a large-scale mapping between one region of the brain to another, created from fMRI or DTI. Data are from a multitude of labs and experiments. The data are <a href="https://www.biorxiv.org/content/early/2018/04/24/188706" target="_blank">run through ndmg</a>, and after processing, we provide summary statistics, QA, and the projectomes themselves.</p>
+        <p>This page hosts projectomes produced with <a href="https://github.com/neurodata/ndmg" target="_blank">NeuroData's MRI Graphs pipeline (ndmg)</a>. A 'projectome' is a large-scale mapping between regions of the brain, created from fMRI or DTI. Data are from a multitude of labs and experiments. The data are <a href="https://www.biorxiv.org/content/early/2018/04/24/188706" target="_blank">run through ndmg</a>, and after processing, we provide summary statistics, QA, and the projectomes themselves.</p>
     </div>
     
     <h3 id="links">Links</h3>

--- a/content/tools/mgc.yaml
+++ b/content/tools/mgc.yaml
@@ -1,6 +1,15 @@
 $order: 1
 name: MGC
-lang: R
+packages:
+  - name: "MGC-R" 
+    github: neurodata/mgc
+    lang: R
+  - name: "mgcpy"
+    github: "NeuroDataDesign/mgcpy"
+    lang: Python
+  - name: "mgc-matlab"
+    github: "neurodata/mgc-matlab"
+    lang: Matlab
 heading: Non-parametric hypothesis testing
 description: Multiscale Graph Correlation (MGC) is a framework for universally consistent testing high-dimensional and non-Euclidean data.
 
@@ -9,8 +18,7 @@ local: True
 type: "vectors"
 
 api: 
-github: neurodata/mgc
-docs: 
+docs: https://mgcpy.readthedocs.io/en/latest/
 manuscripts: 
 - shen2016discovering
 press: 

--- a/partials/people.html
+++ b/partials/people.html
@@ -2,7 +2,7 @@
     <span class="ids name">
         {{item.name}}
     </span>
-    {% if item.position %}
+    {% if item.position and (doc.title=="About" or doc.title=="Alumni") %}
     <span class="ids position"> 
         {{item.position}}
     </span>


### PR DESCRIPTION
Not one, not two, but *three* changes in one PR!

- Updated mgc section of https://neurodata.io/tools/
- Updated person titles to only appear on "about" page
- Changed projectome 'about' wording again out of OCD