### PR TITLE
proper talk links

### DIFF
--- a/content/tools/graspy.yaml
+++ b/content/tools/graspy.yaml
@@ -10,7 +10,7 @@ examples: "https://graspy.neurodata.io/tutorial.html"
 
 slides:
   - header: "graspy"
-    link: "https://neurodata.io/talks/DiPy19.html"
+    link: "https://neurodata.io/talks/graspy.html"
 
 details:
   - "Simple, flexible and powerful graph analysis library grounded in statistical theories."

--- a/content/tools/ndmg.yaml
+++ b/content/tools/ndmg.yaml
@@ -10,7 +10,7 @@ examples: "https://ndmg.neurodata.io/"
 
 slides:
   - header: "ndmg"
-    link: "https://neurodata.io/talks/StructuralConnectomics_ndmg.pptx"
+    link: "https://neurodata.io/talks/ndmg.pdf"
 
 details:
   - "ndmg provides robust and reliable estimates of MRI connectivity across a wide range of datasets at 1mm resolution, across 25 parcellations, ranging in size from 48 to 72,000 nodes, all in MNI152 standard space."

--- a/content/tools/reg.yaml
+++ b/content/tools/reg.yaml
@@ -10,7 +10,7 @@ examples: "https://nbviewer.jupyter.org/github/neurodata/ardent/blob/master/demo
 
 slides:
   - header: "reg"
-    link: "https://neurodata.io/talks/tward_neuronex2.pdf"
+    link: "https://neurodata.io/talks/ardent.pdf"
 
 details:
   - 'NeuroData''s open-source Python <a href="https://github.com/neurodata/ardent">package</a> that performs affine and deformable (LDDMM) image registration.'


### PR DESCRIPTION
Simplified names to talks, to just be the name of each tool.
Each link is for the slides to talk given on the day the tool was presented during workshop.
`neurodata/talks` repo updates as well to account for new names.