### PR TITLE
Example for Viewing Local Data in Neuroglancer

### DIFF
--- a/content/guides/upload.py
+++ b/content/guides/upload.py
@@ -1,0 +1,43 @@
+import argparse
+import numpy as np
+from cloudvolume import CloudVolume
+import tifffile as tf
+from joblib import Parallel
+
+
+def create_image_layer(destination, num_resolutions):
+	info = CloudVolume.create_new_info(
+		num_channels 	= 1,
+		layer_type	= 'image',
+		data_type	= 'uint8',
+		encoding	= 'raw',
+		resolution	= [1,1,1],
+		voxel_offset	= [0, 0, 0],
+		chunk_size	= [5, 5, 5],
+		volume_size	= [10, 10, 10]
+	)
+
+	vol = CloudVolume(destination, compress=False, info=info, parallel=True)
+	print(vol.info)
+	vol.commit_info()
+	return vol
+
+#python upload.py **source** **destination**
+# python upload.py ./test/ precomputed://file://test_output
+def main():
+	parser = argparse.ArgumentParser('Convert a folder of tif files to neuroglancer format')
+	parser.add_argument('destination', help='destination path')
+	num_resolutions = 1
+
+	args = parser.parse_args()
+
+	im = np.random.randint(0, 256, size=[10, 10, 10], dtype=np.uint8)
+	tf.imsave('test.tif', im)
+	im = tf.imread('test.tif')
+	
+	vol = create_image_layer(args.destination, num_resolutions)
+
+	vol[:,:,:] = im
+
+if __name__ == "__main__":
+	main()

--- a/content/guides/upload.py
+++ b/content/guides/upload.py
@@ -22,11 +22,11 @@ def create_image_layer(destination, num_resolutions):
 	vol.commit_info()
 	return vol
 
-#python upload.py **source** **destination**
+# python upload.py **source** **destination**
 # python upload.py ./test/ precomputed://file://test_output
 def main():
 	parser = argparse.ArgumentParser('Convert a folder of tif files to neuroglancer format')
-	parser.add_argument('destination', help='destination path')
+	parser.add_argument('destination', help='Destination path for precomputed files, pre-pended with precomputed://file://, e.g. precomputed://file://**path** will write the files to ./**path**')
 	num_resolutions = 1
 
 	args = parser.parse_args()

--- a/content/guides/visualization.md
+++ b/content/guides/visualization.md
@@ -29,7 +29,7 @@ At this point, the data can be viewed in neuroglancer:
 
 1. Navigate to a place where neuroglancer is hosted, e.g. [viz.neurodata.io/](https://viz.neurodata.io/)
 1. Click the "+" icon to add a source
-1. In the Source field, type precomputed://file://127.0.0.1:9000
+1. In the Source field, type precomputed://http://127.0.0.1:9000
 1. In the green bar above the Source field, make sure the source format is selected to be "image" (not "new" or "auto" etc.)
 
 ### Selected links

--- a/content/guides/visualization.md
+++ b/content/guides/visualization.md
@@ -16,6 +16,22 @@ NeuroData maintains a Neuroglancer [fork](https://github.com/neurodata/neuroglan
 1. Export and load state to/from an external JSON server
 1. Segmentation overlays for ARA and Zbrain ontologies, at [ara.viz.neurodata.io](https://ara.viz.neurodata.io) and [zbrain.viz.neurodata.io](https://zbrain.viz.neurodata.io)
 
+### View Local Images in Neuroglancer Example
+
+The following example can be used to help you view your own images in neuroglancer. This example uses a [script]([url('/content/guides/upload.py')]) to generate a test image, then convert from tif to precomputed format. It will also require running a [script]([url('[script]([url('/content/guides/upload.py')])')]) from neuroglancer to host the local data:
+
+1. mkdir ./test_output
+1. python upload.py precomputed://file://test_output/
+1. cd ./test_output
+1. python **path to neuroglancer**/cors_webserver.py
+
+At this point, the data can be viewed in neuroglancer:
+
+1. Navigate to a place where neuroglancer is hosted, e.g. [viz.neurodata.io]([url('viz.neurodata.io')])
+1. Click the "+" icon to add a source
+1. In the Source field, type precomputed://file://127.0.0.1:9000
+1. In the green bar above the Source field, make sure the source format is selected to be "image" (not "new" or "auto" etc.)
+
 ### Selected links
 
 The following URLs link to highlighted visualizations

--- a/content/guides/visualization.md
+++ b/content/guides/visualization.md
@@ -18,12 +18,12 @@ NeuroData maintains a Neuroglancer [fork](https://github.com/neurodata/neuroglan
 
 ### View Local Images in Neuroglancer Example
 
-The following example can be used to help you view your own images in neuroglancer. This example uses a [script]([url('/content/guides/upload.py')]) to generate a test image, then convert from tif to precomputed format. It will also require running a [script]([url('[script]([url('/content/guides/upload.py')])')]) from neuroglancer to host the local data:
+The following example can be used to help you view your own images in neuroglancer. This example uses a [script]([url('/content/guides/upload.py')]) to generate a test image, then convert from tif to precomputed format. It will also require running a [script]([url('[script]([url('https://github.com/google/neuroglancer/blob/master/cors_webserver.py')])')]) from neuroglancer to host the local data:
 
 1. mkdir ./test_output
 1. python upload.py precomputed://file://test_output/
 1. cd ./test_output
-1. python **path to neuroglancer**/cors_webserver.py
+1. python \*path to neuroglancer\*/cors_webserver.py
 
 At this point, the data can be viewed in neuroglancer:
 

--- a/content/guides/visualization.md
+++ b/content/guides/visualization.md
@@ -32,6 +32,8 @@ At this point, the data can be viewed in neuroglancer:
 1. In the Source field, type precomputed://http://127.0.0.1:9000
 1. In the green bar above the Source field, make sure the source format is selected to be "image" (not "new" or "auto" etc.)
 
+If you see a 10x10x10 cube of random grayscale intensities, the example succeeded.
+
 ### Selected links
 
 The following URLs link to highlighted visualizations

--- a/content/guides/visualization.md
+++ b/content/guides/visualization.md
@@ -27,7 +27,7 @@ The following example can be used to help you view your own images in neuroglanc
 
 At this point, the data can be viewed in neuroglancer:
 
-1. Navigate to a place where neuroglancer is hosted, e.g. [viz.neurodata.io]([url('viz.neurodata.io')])
+1. Navigate to a place where neuroglancer is hosted, e.g. [viz.neurodata.io/]([url('https://viz.neurodata.io/')])
 1. Click the "+" icon to add a source
 1. In the Source field, type precomputed://file://127.0.0.1:9000
 1. In the green bar above the Source field, make sure the source format is selected to be "image" (not "new" or "auto" etc.)

--- a/content/guides/visualization.md
+++ b/content/guides/visualization.md
@@ -18,7 +18,7 @@ NeuroData maintains a Neuroglancer [fork](https://github.com/neurodata/neuroglan
 
 ### View Local Images in Neuroglancer Example
 
-The following example can be used to help you view your own images in neuroglancer. This example uses a [script]([url('/content/guides/upload.py')]) to generate a test image, then convert from tif to precomputed format. It will also require running a [script]([url('https://github.com/google/neuroglancer/blob/master/cors_webserver.py')])  from neuroglancer to host the local data:
+The following example can be used to help you view your own images in neuroglancer. This example uses a [script]([url('/content/guides/upload.py')]) to generate a test image, then convert from tif to precomputed format. It will also require running a [script](https://github.com/google/neuroglancer/blob/master/cors_webserver.py)  from neuroglancer to host the local data:
 
 1. mkdir ./test_output
 1. python upload.py precomputed://file://test_output/
@@ -27,7 +27,7 @@ The following example can be used to help you view your own images in neuroglanc
 
 At this point, the data can be viewed in neuroglancer:
 
-1. Navigate to a place where neuroglancer is hosted, e.g. [viz.neurodata.io/]([url('https://viz.neurodata.io/')])
+1. Navigate to a place where neuroglancer is hosted, e.g. [viz.neurodata.io/](https://viz.neurodata.io/)
 1. Click the "+" icon to add a source
 1. In the Source field, type precomputed://file://127.0.0.1:9000
 1. In the green bar above the Source field, make sure the source format is selected to be "image" (not "new" or "auto" etc.)

--- a/content/guides/visualization.md
+++ b/content/guides/visualization.md
@@ -18,12 +18,12 @@ NeuroData maintains a Neuroglancer [fork](https://github.com/neurodata/neuroglan
 
 ### View Local Images in Neuroglancer Example
 
-The following example can be used to help you view your own images in neuroglancer. This example uses a [script]([url('/content/guides/upload.py')]) to generate a test image, then convert from tif to precomputed format. It will also require running a [script]([url('[script]([url('https://github.com/google/neuroglancer/blob/master/cors_webserver.py')])')]) from neuroglancer to host the local data:
+The following example can be used to help you view your own images in neuroglancer. This example uses a [script]([url('/content/guides/upload.py')]) to generate a test image, then convert from tif to precomputed format. It will also require running a [script]([url('https://github.com/google/neuroglancer/blob/master/cors_webserver.py')])  from neuroglancer to host the local data:
 
 1. mkdir ./test_output
 1. python upload.py precomputed://file://test_output/
 1. cd ./test_output
-1. python \*path to neuroglancer\*/cors_webserver.py
+1. python \*\*path to neuroglancer\*\*/cors_webserver.py
 
 At this point, the data can be viewed in neuroglancer:
 

--- a/content/guides/visualization.md
+++ b/content/guides/visualization.md
@@ -18,7 +18,7 @@ NeuroData maintains a Neuroglancer [fork](https://github.com/neurodata/neuroglan
 
 ### View Local Images in Neuroglancer Example
 
-The following example can be used to help you view your own images in neuroglancer. This example uses a [script]([url('/content/guides/upload.py')]) to generate a test image, then convert from tif to precomputed format. It will also require running a [script](https://github.com/google/neuroglancer/blob/master/cors_webserver.py)  from neuroglancer to host the local data:
+The following example can be used to help you view your own images in neuroglancer. This example uses a [script]([url('/content/guides/upload.py')]) to generate a test image, then convert from tif to precomputed format. You will need to use Python 3, and install all the dependencies of the script, including tifffile, cloudvolume, and joblib. It will also require running a [script](https://github.com/google/neuroglancer/blob/master/cors_webserver.py)  from neuroglancer to host the local data:
 
 1. mkdir ./test_output
 1. python upload.py precomputed://file://test_output/


### PR DESCRIPTION
I have fielded multiple questions regarding viewing local data in neuroglancer. Hopefully this example will answer those questions. This example uses cloudvolume and local hosting to make a tif file viewable in neuroglancer.

The only untested item on my end is:
-Will the links work in the website?

My questions are:
-Is it appropriate to put upload.py where I put it?
-Can someone else please try this example to make sure it works?
-Is the language clear?