### PR TITLE
code of conduct page

### DIFF
--- a/content/about/codeofconduct.md
+++ b/content/about/codeofconduct.md
@@ -1,0 +1,43 @@
+---
+$title@: Code of Conduct
+$order: 4
+---
+
+[TOC]
+
+
+*This code of conduct is heavily based on that of [Microsoft](https://opensource.microsoft.com/codeofconduct/):*
+
+### Conduct
+
+**This code of conduct outlines expectations for participation in Neurodata-managed open source communities, as well as steps for reporting unacceptable behavior. We are committed to providing a welcoming and inspiring community for all. People violating this code of conduct may be banned from the community.**
+
+Our open source communities strive to:
+
+- **Be friendly and patient:** Remember you might not be communicating in someone else's primary spoken or programming language, and others may not have your level of understanding.
+- **Be welcoming:** Our communities welcome and support people of all backgrounds and identities. This includes, but is not limited to members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+- **Be respectful:** We are a world-wide community of professionals, and we conduct ourselves professionally. Disagreement is no excuse for poor behavior and poor manners. Disrespectful and unacceptable behavior includes, but is not limited to:
+    - Violent threats or language.
+    - Discriminatory or derogatory jokes and language.
+    - Posting sexually explicit or violent material.
+    - Posting, or threatening to post, people's personally identifying information ("doxing").
+    - Insults, especially those using discriminatory terms or slurs.
+    - Behavior that could be perceived as sexual attention.
+    - Advocating for or encouraging any of the above behaviors.
+- **Understand Disagreements:** Disagreements, both social and technical, are useful learning opportunities. Seek to understand the other viewpoints and resolve differences constructively.
+- This code is not exhaustive or complete. It serves to capture our common understanding of a productive, collaborative environment. We expect the code to be followed in spirit as much as in the letter.
+
+
+### Reporting Code of Conduct Issues
+
+We encourage all communities to resolve issues on their own whenever possible. This builds a broader and deeper understanding and ultimately a healthier interaction. In the event that an issue cannot be resolved locally, please feel free to report your concerns by contacting support@neurodata.io.
+
+In your report please include:
+
+- Your contact information.
+- Names (real, usernames or pseudonyms) of any individuals involved. If there are additional witnesses, please include them as well.
+- Your account of what occurred, and if you believe the incident is ongoing. If there is a publicly available record (e.g. a mailing list archive or a public chat log), please include a link or attachment.
+- Any additional information that may be helpful.
+- All reports will be reviewed by a multi-person team and will result in a response that is deemed necessary and appropriate to the circumstances. Where additional perspectives are needed, the team may seek insight from others with relevant expertise or experience. The confidentiality of the person reporting the incident will be kept at all times. Involved parties are never part of the review team.
+
+Anyone asked to stop unacceptable behavior is expected to comply immediately. If an individual engages in unacceptable behavior, the review team may take any action they deem appropriate, including a permanent ban from the community.


### PR DESCRIPTION
We are currently trying to update our repositories to have a code of conduct. I propose we have a single Neurodata code of conduct on our website that we can link.

I basically copied and pasted from [Microsoft's code of conduct](https://opensource.microsoft.com/codeofconduct/) with some necessary changes.