### PR TITLE
Add `self` to lab event organizing

### DIFF
--- a/content/other/community_jobs.html
+++ b/content/other/community_jobs.html
@@ -41,9 +41,8 @@ Maintains a guide on how to file for different types of reimbursement [Attach Li
 <h5>Lab Cleaning/Maintenance (Alex Loftus)</h5>
 <p>In charge of organizing monthly(?) cleanings of the lab area as well as making sure that coffee is always available.</p>
 
-<h5>Lab Event Organizer ()</h5>
+<h5>Lab Event Organizer (Ben Pedigo)</h5>
 <p>In charge of lab events/activities that are recreational in nature.</p>
+
 <h6>Monthly Hike ()</h6>
-<p>[Jovo please elaborate]</p>
-<h6>Social Events ()</h6>
 <p>[Jovo please elaborate]</p>


### PR DESCRIPTION
I suspect that "social events" was redundant with "lab events" so I removed it. If someone sees how those two things were different, please object @jovo 