### PR TITLE
Update join us page

### DIFF
--- a/content/pages/join.html
+++ b/content/pages/join.html
@@ -88,21 +88,18 @@ $hidden: true
         <br><br>
         <b>Research Questions:</b> If you have any questions about our research, please reach out directly to the experts: 
         <ul>
-            <li> <i> Lifelong/Continual Learning: </i></li> <a href="https://proglearn.neurodata.io/" >proglearn website</a> or <a href="jdey4@jhmi.edu">Jayanta</a>
-            <li> <i> Big Data/ Open Connectome Project: </i></li> <a href="https://neurodata.io/project/ocp/" >OCP Website</a> or <a href="tathey1@jhmi.edu">Tommy</a>
-            <li> <i> Nonlinear registration:</i></li> <a href="https://cloudreg.neurodata.io/" >cloudreg website</a> or <a href="vchandr6@jhmi.edu">Vikram</a>
-            <li> <i> Network analysis: </i></li> <a href="https://graspologic.readthedocs.io/en/latest/" >graspologic website</a> or <a href="bpedigo@jhu.edu">Ben Pedigo</a>
-            <li> <i> Hypothesis testing: </i></li> <a href="https://hyppo.neurodata.io/" >hyppo website</a> or <a href="spanda3@jhu.edu">Sambit</a>
-            <li> <i> Deep learning and decision forests: </i></li> <a href="https://sporf.neurodata.io/" >sporf website</a> or <a href="kalab2009@gmail.com">Kaleab</a>
-            <li> <i> Human Connectomics: </i></li> <a href="https://neurodata.io/mri/" >m2g website</a> or <a href="j1c@jhu.edu">Jaewon</a>
-            <li> <i> Natural vs machine intelligence/learning: </i></li> <a href="jhow@jhu.edu">Javier</a>
-            <li> <i> Causal inference: </i></li> <a href="ebridge2@jhu.edu">Eric</a>
-            <li> <i> COVID </i></li> <a href="mpowel35@jhmi.edu">Mike</a>
-            <li> <i> Scalable analytics </i></li> <a href="mmadhya1@jhu.edu">Meghana</a>
-            <li> <i> Out of distribution learning </i></li> <a href="nhuang19@jhu.edu">Teresa</a>
-
-
-
+            <li> <i> Lifelong/Continual Learning: </i> <a href="https://proglearn.neurodata.io/" >proglearn website</a> or <a href="jdey4@jhmi.edu">Jayanta</a></li>
+            <li> <i> Big Data/ Open Connectome Project: </i> <a href="https://neurodata.io/project/ocp/" >OCP Website</a> or <a href="tathey1@jhmi.edu">Tommy</a></li>
+            <li> <i> Nonlinear registration:</i> <a href="https://cloudreg.neurodata.io/" >cloudreg website</a> or <a href="vchandr6@jhmi.edu">Vikram</a></li>
+            <li> <i> Network analysis: </i> <a href="https://graspologic.readthedocs.io/en/latest/" >graspologic website</a> or <a href="bpedigo@jhu.edu">Ben Pedigo</a></li>
+            <li> <i> Hypothesis testing: </i> <a href="https://hyppo.neurodata.io/" >hyppo website</a> or <a href="spanda3@jhu.edu">Sambit</a></li>
+            <li> <i> Deep learning and decision forests: </i> <a href="https://sporf.neurodata.io/" >sporf website</a> or <a href="kalab2009@gmail.com">Kaleab</a></li>
+            <li> <i> Human Connectomics: </i> <a href="https://neurodata.io/mri/" >m2g website</a> or <a href="j1c@jhu.edu">Jaewon</a></li>
+            <li> <i> Natural vs machine intelligence/learning: </i> <a href="jhow@jhu.edu">Javier</a></li>
+            <li> <i> Causal inference: </i> <a href="ebridge2@jhu.edu">Eric</a></li>
+            <li> <i> COVID </i> <a href="mpowel35@jhmi.edu">Mike</a></li>
+            <li> <i> Scalable analytics </i> <a href="mmadhya1@jhu.edu">Meghana</a></li>
+            <li> <i> Out of distribution learning </i> <a href="nhuang19@jhu.edu">Teresa</a></li>
         </ul>
     </p>
 

--- a/content/pages/join.html
+++ b/content/pages/join.html
@@ -10,7 +10,7 @@ $hidden: true
 
 <div class="join-page">
     <p>NeuroData is literally always hiring exceptional individuals.  If you think you'd like to work with us in any capacity, please
-        <a href="mailto:join@neurodata.io">email us</a>
+        contact us
         now!  Some thoughts that might be useful prior to emailing us to consider further:</p>
 
     <ol>
@@ -27,13 +27,13 @@ $hidden: true
             <em>you</em>.  Each individual benefits from unique circumstances.  We wrote this
             <a href="https://bitsandbrains.io/2018/08/31/sig-and-feas.html">blog post</a>
             which describes out thoughts on choosing projects, but it is also relevant for choosing teams. If you are reading this far, it seems likely that the kind of work we do is intrinsically motivating for you.  Even if not, and you think we could help find a team better aligned with your dreams, please
-            <a href="mailto:join@neurodata.io">email us</a>.</li>
+            contact us.</li>
 
         <li>To create the most peaceful and productive environment, our team has constructed these
             <a href="https://neurodata.io/about/agreements/">agreements</a>, which we all adhere to. This includes  treating everyone with respect on the team, and at any team events.  See our
             <a href="https://neurodata.io/about/agreements/#respect">code of conduct</a>
             for details.  If it seems like that kind of environment would suit you well, please
-            <a href="mailto:join@neurodata.io">email us</a>.</li>
+            contact us.</li>
 
         <li>If you are interested in pursuing graduate studies with us, there are many different programs that are available.  The
             <a href="https://www.bme.jhu.edu/graduate/overview/">Johns Hopkins University Biomedical Engineering graduate programs</a>
@@ -51,39 +51,69 @@ $hidden: true
             <a href="http://neuroscience.jhu.edu/graduate">Neuroscience</a>. If you are interested in graduate studies with us in a different program (e.g.,
             <a href="https://www.janelia.org/you-janelia/students-postdocs/joint-graduate-program">JHU/Janelia</a>, or
             <a href="https://engineering.jhu.edu/ece/graduate-studies/">ECE@JHU</a>), please also feel free to
-            <a href="mailto:join@neurodata.io">email us</a>.
+            contact us.
         </li>
 
         <li>If you are already enrolled at JHU and are interested in joining the lab, the simplest route is to enroll in the year-long project-based course we offer called
             <a href="https://neurodatadesign.github.io/Syllabus/">NeuroData Design</a>.  A key motivation for offering this course was to ensure that we could work with as many amazing individuals as possible.  If for some reason, enrolling in the course does not seem feasible for you, please
-            <a href="mailto:join@neurodata.io">email us</a>
+            contact us
             and we will try to figure out some other arrangement.
         </li>
 
         <li>If you are a visiting or exchange student, please see
             <a href="https://apply.jhu.edu/visiting-and-exchange-students/">JHU's official exchange program overview</a>, and go through the official process; after you do this,
-            <a href="mailto:join@neurodata.io">email us</a>
+            contact us
             to say you applied.  It is complicated for legal and bureaucratic reasons to accept visiting/exchange students outside these official programs, although it is possible. So, if those programs do not work for any reason, please
-            <a href="mailto:join@neurodata.io">email us</a>.</li>
+            contact us.</li>
     </ol>
 
-    <p>OK, given all the above, we recommend that you email us.  Below we provide an example email.  Note that we will respond within a week in almost all cases.
+    <p>OK, given all the above, please see below on how to best contact us:
     </p>
 
-    <p class="indented">Dear Prof. X,
+    <p class="indented">
+        <b>Chat:</b> Please schedule a time to chat with NeuroData Directer Joshua Vogelstein <a href="https://calendly.com/joshuav/other">here</a>
         <br><br>
-        I have been studying [something quite relevant to your research] for the last [X duration], and I expect to graduate from [Y institution] in [Z expected month]. I recently became interested with your work, specifically, the article "[some article from our group]".<br>
-        I am particularly intrigued by this work because of [X], which is one of the things I am most excited about studying next. I would therefore be thrilled to do [X] for a period of [Y duration] in your group. For your convenience, I have attached my CV, and and an unofficial copy of my transcript. I look forward to hearing from you at your earliest convenience.
-        <br><br>Best, [Some Awesome Person.]</p>
+        <b>Potential Teammates:</b> We are very excited to meet you! Consider reading our <a href="https://neurodata.io/about/agreements/">lab agreements</a> and reaching out to <a href="https://neurodata.io/about/team/">team members</a> in addition to finding a time to chat with Jovo directly. 
+        <br><br>
+        <b>Lab Logistics and Grant:</b> <br>
+            <ul>
+                <li> <i> Logistics: </i> email <a href="kbiasuc1@jhu.edu">Kim Biasucci</a>  </li>
+                <li> <i> Grant pre-award: </i> email <a href="hlockar1@jhu.edu">Heather Lockard Wheeler</a> </li>
+                <li> <i> Grant ongoing award: </i> email <a href="darnold@jhu.edu">Dawn Arnold</a> </li>
+            </ul>
+        <p class="indented">
+        <b>NeuroData Design:</b> Please review the <a href="https://neurodatadesign.io/">class website</a>, and email <a href="hxu36@jhu.edu">Hao</a> any remaining questions
+        <br><br>
+        <b>Speaking Engagements:</b> If you'd like Joshua Vogelstein to speak at an event, please coordinate with <a href="kbiasuc1@jhu.edu">Kim Biasucci</a>
+        <br><br>
+        <b>Research Questions:</b> If you have any questions about our research, please reach out directly to the experts: 
+        <ul>
+            <li> <i> Lifelong/Continual Learning: </i></li> <a href="https://proglearn.neurodata.io/" >proglearn website</a> or <a href="jdey4@jhmi.edu">Jayanta</a>
+            <li> <i> Big Data/ Open Connectome Project: </i></li> <a href="https://neurodata.io/project/ocp/" >OCP Website</a> or <a href="tathey1@jhmi.edu">Tommy</a>
+            <li> <i> Nonlinear registration:</i></li> <a href="https://cloudreg.neurodata.io/" >cloudreg website</a> or <a href="vchandr6@jhmi.edu">Vikram</a>
+            <li> <i> Network analysis: </i></li> <a href="https://graspologic.readthedocs.io/en/latest/" >graspologic website</a> or <a href="bpedigo@jhu.edu">Ben Pedigo</a>
+            <li> <i> Hypothesis testing: </i></li> <a href="https://hyppo.neurodata.io/" >hyppo website</a> or <a href="spanda3@jhu.edu">Sambit</a>
+            <li> <i> Deep learning and decision forests: </i></li> <a href="https://sporf.neurodata.io/" >sporf website</a> or <a href="kalab2009@gmail.com">Kaleab</a>
+            <li> <i> Human Connectomics: </i></li> <a href="https://neurodata.io/mri/" >m2g website</a> or <a href="j1c@jhu.edu">Jaewon</a>
+            <li> <i> Natural vs machine intelligence/learning: </i></li> <a href="jhow@jhu.edu">Javier</a>
+            <li> <i> Causal inference: </i></li> <a href="ebridge2@jhu.edu">Eric</a>
+            <li> <i> COVID </i></li> <a href="mpowel35@jhmi.edu">Mike</a>
+            <li> <i> Scalable analytics </i></li> <a href="mmadhya1@jhu.edu">Meghana</a>
+            <li> <i> Out of distribution learning </i></li> <a href="nhuang19@jhu.edu">Teresa</a>
 
-    <p>In conclusion, a brief checklist that may help you of what to include in your email to faculty:</p>
+
+
+        </ul>
+    </p>
+
+    <p>In conclusion, if you plan to chat with faculty or a member of the lab, please be prepared to discuss the following::</p>
 
     <ol>
         <li>Excitement about working on something specific relevant to the individual you are contacting</li>
         <li>Relevant background experience</li>
         <li>Desired duration and title of position</li>
         <li>Up to date cv</li>
-        <li>Remember, the shorter the better, this is just to get your foot in the door.</li>
+        <li>Remember, this is just to get your foot in the door.</li>
     </ol>
 
     <p>Good luck!</p>


### PR DESCRIPTION
Fixes #480. 
Updates Join us page to replace instances of "email us" with "contact us", and specifies how to best contact us per jovo's current email autoresponse.