### PR TITLE
Update Jaewon bibs

### DIFF
--- a/content/bibs/pubs.bib
+++ b/content/bibs/pubs.bib
@@ -1336,19 +1336,6 @@
 	primaryClass = {cs.LG}
 },
 
-@article{chung2021valid,
-	title = {Valid Two-Sample Graph Testing via Optimal Transport Procrustes and Multiscale Graph Correlation with Applications in Connectomics},
-	author = {Jaewon Chung and Bijan Varjavand and Jesus Arroyo and Anton Alyakin and Joshua Agterberg and Minh Tang and Joshua T. Vogelstein and Carey E. Priebe},
-	author+an = {1=trainee;3=trainee;7=highlight},
-	year = {2021},
-	keywords = {in-review},
-	url = {https://arxiv.org/abs/1911.02741},
-	journal = {arXiv},
-	eprint = {1911.02741},
-	archivePrefix = {arXiv},
-	primaryClass = {stat.ME}
-},
-
 @article{Lyzinski2014,
 	title = {Seeded Graph Matching Via Joint Optimization of Fidelity and Commensurability},
 	author = {Patsolic, Heather and Adali, Sancar and Vogelstein, Joshua T. and Park, Youngser 
@@ -4049,7 +4036,7 @@
 	journal = {Statistics in Medicine},
   doi = {10.1002/sim.9868},
   pmid = {37553084}
-}
+},
 
 @article{athey2023brainline,
 	title = {BrainLine: An Open Pipeline for Connectivity Analysis of Heterogeneous Whole-Brain Fluorescence Volumes},
@@ -4060,7 +4047,7 @@
 	keywords = {tech},
 	url = {https://link.springer.com/article/10.1007/s12021-023-09638-2},
 	journal = {Neuroinformatics}
-}
+},
 
 @inproceedings{wang2023polarity,
   title={Polarity is all you need to learn and transfer faster}, 
@@ -4072,7 +4059,7 @@
   arxiv={2303.17589},
   author+an = {1=trainee;2=trainee;3=trainee;4=trainee;5=highlight},
   keywords={conference}
-  }
+  },
 
 @inproceedings{Wang_2023_ICCV,
     author    = {Wang, Qingyang and Powell, Mike A. and Geisa, Ali and Bridgeford, Eric and Priebe, Carey E. and Vogelstein, Joshua T.},
@@ -4081,11 +4068,10 @@
     month     = {October},
     year      = {2023},
     pages     = {22551-22559},
-    abstract={Why do brains have inhibitory connections? Why do deep networks have negative weights? We believe representing functions is the primary role of both (i) the brain in natural intelligence, and (ii) deep networks in artificial intelligence. Our answer to why there are inhibitory/negative weights is: to learn more functions. We prove that, in the absence of negative weights, neural networks with non-decreasing activation functions are not universal approximators. While this may be an intuitive result to some, to the best of our knowledge, there is no formal theory, in either machine learning or neuroscience, that demonstrates why negative weights are crucial in the context of representation capacity. Further, we provide insights on the geometric properties of the representation space that non-negative deep networks cannot represent. We expect these insights will yield a deeper understanding of more sophisticated inductive priors imposed on the distribution of weights that lead to more efficient biological and machine learning.},
     arxiv={2208.03211v8},
     author+an = {1=trainee;2=trainee;3=trainee;4=trainee;6=highlight},
     keywords={conference}
-}
+},
 
 @article{de2023value,
   title={The value of out-of-distribution data},
@@ -4096,4 +4082,12 @@
   url = {https://proceedings.mlr.press/v202/de-silva23a.html},
   journal={International Conference on Machine Learning},
   keywords={conference}
+},
+
+@article{chung2023heritability,
+  title     = {The Heritability of Human Connectomes: a Causal Modeling Analysis},
+  author    = {Chung, Jaewon and Bridgeford, Eric W and Powell, Michael and Pisner, Derek and Vogelstein, Joshua T},
+  journal   = {bioRxiv},
+  year      = {2023},
+  publisher = {Cold Spring Harbor Laboratory}
 }

--- a/content/bibs/pubs.bib
+++ b/content/bibs/pubs.bib
@@ -4068,6 +4068,7 @@
     month     = {October},
     year      = {2023},
     pages     = {22551-22559},
+    abstract={Why do brains have inhibitory connections? Why do deep networks have negative weights? We believe representing functions is the primary role of both (i) the brain in natural intelligence, and (ii) deep networks in artificial intelligence. Our answer to why there are inhibitory/negative weights is: to learn more functions. We prove that, in the absence of negative weights, neural networks with non-decreasing activation functions are not universal approximators. While this may be an intuitive result to some, to the best of our knowledge, there is no formal theory, in either machine learning or neuroscience, that demonstrates why negative weights are crucial in the context of representation capacity. Further, we provide insights on the geometric properties of the representation space that non-negative deep networks cannot represent. We expect these insights will yield a deeper understanding of more sophisticated inductive priors imposed on the distribution of weights that lead to more efficient biological and machine learning.},
     arxiv={2208.03211v8},
     author+an = {1=trainee;2=trainee;3=trainee;4=trainee;6=highlight},
     keywords={conference}


### PR DESCRIPTION
- The 2021 arxiv entry is no longer needed as published version is in [L3308](https://github.com/neurodata/neurodata.io/blob/9ed502f50f5a9d7eca53e0780b3cffac0571eb93/content/bibs/pubs.bib#L3308)
- Add heritability paper
- Add commas in the last few entries