### PR TITLE
fix bib

### DIFF
--- a/content/bibs/pubs.bib
+++ b/content/bibs/pubs.bib
@@ -1214,7 +1214,7 @@
 	author={Vogelstein, Joshua T and Verstynen, Timothy and Kording, Konrad P and Isik, Leyla and Krakauer, John W and Etienne-Cummings, Ralph and Ogburn, Elizabeth L and Priebe, Carey E and Burns, Randal and Kutten, Kwame and Knierim, James J and Potash, James B and Hartung, Thomas and Smirnova, Lena and Worley, Paul and Savonenko, Alena and Phillips, Ian and Miller, Michael I and Vidal, Rene and Sulam, Jeremias and Charles, Adam and Cowan, Noah J and Bichuch, Maxim and Venkataraman, Archana and Li, Chen and Thakor, Nitish and Kebschull, Justus M and Albert, Marilyn and Xu, Jinchong and Shuler, Marshall Hussain and Caffo, Brian and Ratnanather, Tilak and Geisa, Ali and Roh, Seung-Eon and Yezerets, Eva and Madhyastha, Meghana and How, Javier J and Tomita, Tyler M and Dey, Jayanta and Huang, Ningyuan and Shin, Jong M and Kinfu, Kaleab Alemayehu and Chaudhari, Pratik and Baker, Ben and Schapiro, Anna and Jayaraman, Dinesh and Eaton, Eric and Platt, Michael and Ungar, Lyle and Wehbe, Leila and Kepecs, Adam and Christensen, Amy and Osuagwu, Onyema and Brunton, Bing and Mensh, Brett and Muotri, Alysson R and Silva, Gabriel and Puppo, Francesca and Engert, Florian and Hillman, Elizabeth and Brown, Julia and White, Chris and Yang, Weiwei},
 	author+an={1=highlight,33=trainee;35=trainee;36=trainee;37=trainee;38=trainee;39=trainee;40=trainee;41=trainee;42=trainee},
 	year={2022},
-	keywords={peer-reviewed},
+	keywords={conference},
 	url={https://arxiv.org/abs/2201.07372},
 	month={1},
 	journal={2nd Conference on Lifelong Learning Agents, 2023}
@@ -4182,11 +4182,12 @@
 }, 
 
 @article{desilva2024prospective,
-  title={Prospective Learning: Principled Extrapolation to the Future},
+  title={Prospective Learning: Learning for a Dynamic Future},
+  url={https://arxiv.org/abs/2411.00109},
   author={De Silva, Ashwin and Ramesh, Rahul and Yang*, Rubing and Yu, Siyu and Vogelstein, Joshua T and Chaudhari, Pratik},
   journal={Advances in neural information processing systems},
   year={2024},
-  keywords={peer-reviewed},
+  keywords={conference},
 },
 
 @article{xu2024challenges,


### PR DESCRIPTION
* fix title for "Prospective Learning: Learning for a Dynamic Future"
* fix the classification `peer-reviewed` --> `conference`