### PR TITLE
Fix L4DC 2026 paper title (verified against the program page)

### DIFF
--- a/content/bibs/pubs.bib
+++ b/content/bibs/pubs.bib
@@ -4294,10 +4294,10 @@
 
 
 @inproceedings{bai2025optimalcontrolfutureprospective,
-	title={Optimal control of the future via prospective learning with control},
+	title={Optimal Control of the Future via Prospective Foraging},
 	author={Yuxin Bai and Aranyak Acharyya and Ashwin De Silva and Zeyu Shen and James Hassett and Joshua T. Vogelstein},
 	author+an={1=trainee;2=trainee;4=trainee;6=highlight},
-	year={2025},
+	year={2026},
 	booktitle={Learning for Dynamics and Control (L4DC)},
 	url={https://arxiv.org/abs/2511.08717},
 	keywords={conference},


### PR DESCRIPTION
Corrects `bai2025optimalcontrolfutureprospective`'s title/year to match the actual L4DC 2026 program listing (Poster Session 4, item 19: "Optimal Control of the Future via Prospective Foraging"). Supersedes #891 for this entry — see #891 for why its two other changes (`@inproceedings`→`@article` on the AGI-2025 entries) are incorrect.