### PR TITLE
Trim print fonts to reduce PDF file size

### DIFF
--- a/partials/base_head_partial.html
+++ b/partials/base_head_partial.html
@@ -28,7 +28,7 @@
     <link rel="stylesheet" href="{{stylesheet}}" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,600;0,700;1,400;1,600&family=Oswald:wght@500;700&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400;0,700;1,400&family=Oswald:wght@500;700&display=swap">
     {% if env.name == 'prod' %}
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-69121088-1"></script>

--- a/source/css/styles.97.css
+++ b/source/css/styles.97.css
@@ -4016,7 +4016,10 @@ body.person-detail .more-info p {
     color: #333;
   }
   .cv-item .position {
-    font-weight: 600;
+    /* 700 (not 600) so this reuses the same EB Garamond bold file that
+       <strong> (the pub-list highlighted-author tag) already needs --
+       one fewer font weight to embed */
+    font-weight: 700;
     color: #161616;
   }
   .cv-item li p {


### PR DESCRIPTION
Follow-up to #901: was requesting 7 font files (EB Garamond in 5 weights/styles, Oswald in 2) for the print stylesheet; only 5 are actually used anywhere on the page. Real-browser "Save as PDF" was producing a 2MB file, larger than expected for 42 pages of text — likely from embedding unused/duplicate font weights in full rather than subsetting. Drops the unused 600italic and consolidates .position onto the same 700 weight <strong> already needs, instead of a separate 600.