### PR TITLE
Remove 'Funding to lab, current year' line from grant entries

### DIFF
--- a/content/about/jovo.html
+++ b/content/about/jovo.html
@@ -161,8 +161,7 @@ $view: /views/base-person.html
       PI: {{subitem.author}}<br />
       Role on Project: {{subitem.userc}}<br />
       Term: {{subitem.userd}}<br />
-      Funding to lab, entire period: {{subitem.usere|print_price}}<br />
-      Funding to lab, current year: {{subitem.userf|print_price}}
+      Funding to lab, entire period: {{subitem.usere|print_price}}
     </p>
     <p>{{subitem.abstract}}</p>
   </li>
@@ -178,8 +177,7 @@ $view: /views/base-person.html
       PI: {{subitem.author}}<br />
       Role on Project: {{subitem.userc}}<br />
       Term: {{subitem.userd}}<br />
-      Funding to lab, entire period: {{subitem.usere|print_price}}<br />
-      Funding to lab, current year: {{subitem.userf|print_price}}
+      Funding to lab, entire period: {{subitem.usere|print_price}}
     </p>
     <p>{{subitem.abstract}}</p>
   </li>


### PR DESCRIPTION
Removes it from both External Research Support: Current and Completed — they share the same template block.